### PR TITLE
Teach `get_alldenorms` to find ManyToMany fields too

### DIFF
--- a/denorm/denorms.py
+++ b/denorm/denorms.py
@@ -73,7 +73,7 @@ def get_alldenorms():
     alldenorms = []
     for model in gmodels.get_models(include_auto_created=True):
         if not model._meta.proxy:
-            for field in model._meta.fields:
+            for field in model._meta.fields + model._meta.local_many_to_many:
                 if hasattr(field, 'denorm'):
                     if not field.denorm.model._meta.swapped:
                         alldenorms.append(field.denorm)


### PR DESCRIPTION
The denorm_init and denorm_rebuild commands rely on the get_alldenorms function finding all denorm fields.  For Django 1.7 (the only version I tested) `model._meta.fields` does not return ManyToMany fields.  You have to also look at `model._meta.local_many_to_many` to find the ManyToMany fields on a model.

This PR simply concatenates these two field lists together in the `for` loop.
