### PR TITLE
Add denorm_migrate command

### DIFF
--- a/denorm/db/base.py
+++ b/denorm/db/base.py
@@ -168,8 +168,17 @@ class TriggerSet(object):
             else:
                 self.triggers[name] = trigger
 
+    def installed_triggers(self):
+        """returns a list of (trigger_name, table_name) pairs"""
+        raise NotImplementedError
+
     def install(self):
+        """returns a list of triggers installed"""
         raise NotImplementedError
 
     def drop(self):
+        raise NotImplementedError
+
+    def drop_unneeded(self):
+        """drops installed triggers that wouldn't be installed today"""
         raise NotImplementedError

--- a/denorm/db/mysql/triggers.py
+++ b/denorm/db/mysql/triggers.py
@@ -136,7 +136,8 @@ class TriggerSet(base.TriggerSet):
         cursor = self.cursor()
         ret = []
         installed_triggers = self.installed_triggers()
-        installed_triggers = zip(*installed_triggers)[0]  # get just the names
+        if len(installed_triggers) > 0:
+            installed_triggers = zip(*installed_triggers)[0]  # get just the names
         for name, trigger in self.triggers.items():
             if name in installed_triggers:
                 continue

--- a/denorm/db/postgresql/triggers.py
+++ b/denorm/db/postgresql/triggers.py
@@ -175,7 +175,8 @@ class TriggerSet(base.TriggerSet):
         if not cursor.fetchall():
             cursor.execute('CREATE LANGUAGE plpgsql')
         installed_triggers = self.installed_triggers()
-        installed_triggers = zip(*installed_triggers)[0]  # get just the names
+        if len(installed_triggers) > 0:
+            installed_triggers = zip(*installed_triggers)[0]  # get just the names
         for name, trigger in self.triggers.items():
             if name in installed_triggers:
                 continue
@@ -188,6 +189,6 @@ class TriggerSet(base.TriggerSet):
             with transaction.atomic():
                 ret = list(self.install_atomic())
         except AttributeError:
-            ret = self.install_atomic()
+            ret = list(self.install_atomic())
             transaction.commit_unless_managed(using=self.using)
         return ret

--- a/denorm/db/postgresql/triggers.py
+++ b/denorm/db/postgresql/triggers.py
@@ -132,63 +132,21 @@ CREATE TRIGGER %(name)s
 
 
 class TriggerSet(base.TriggerSet):
-    def drop_atomic(self):
+    def cursor(self):
+        if not hasattr(self, '_cursor'):
+            cursor = super(TriggerSet, self).cursor()
+            cursor.execute("SELECT lanname FROM pg_catalog.pg_language WHERE lanname ='plpgsql'")
+            if not cursor.fetchall():
+                cursor.execute('CREATE LANGUAGE plpgsql')
+            self._cursor = cursor
+        return self._cursor
+
+    def drop_trigger(self, trigger_name, table_name):
         qn = self.connection.ops.quote_name
         cursor = self.cursor()
-        for trigger_name, table_name in self.installed_triggers():
-            cursor.execute('DROP TRIGGER %s ON %s;' % (qn(trigger_name), qn(table_name)))
-
-    def drop_unneeded_atomic(self):
-        qn = self.connection.ops.quote_name
-        cursor = self.cursor()
-        needed_triggers = self.triggers.keys()
-        for trigger_name, table_name in self.installed_triggers():
-            if trigger_name in needed_triggers:
-                continue
-            print 'Dropping trigger on %s' % table_name
-            cursor.execute('DROP TRIGGER %s ON %s;' % (qn(trigger_name), qn(table_name)))
-
-    def drop_unneeded(self):
-        try:
-            with transaction.atomic():
-                self.drop_unneeded_atomic()
-        except AttributeError:
-            self.drop_unneeded_atomic()
-            transaction.commit_unless_managed(using=self.using)
+        cursor.execute('DROP TRIGGER %s ON %s;' % (qn(trigger_name), qn(table_name)))
 
     def installed_triggers(self):
         cursor = self.cursor()
         cursor.execute("SELECT pg_trigger.tgname, pg_class.relname FROM pg_trigger LEFT JOIN pg_class ON (pg_trigger.tgrelid = pg_class.oid) WHERE pg_trigger.tgname LIKE 'denorm_%%';")
         return cursor.fetchall()
-
-    def drop(self):
-        try:
-            with transaction.atomic():
-                self.drop_atomic()
-        except AttributeError:
-            self.drop_atomic()
-            transaction.commit_unless_managed(using=self.using)
-
-    def install_atomic(self):
-        cursor = self.cursor()
-        cursor.execute("SELECT lanname FROM pg_catalog.pg_language WHERE lanname ='plpgsql'")
-        if not cursor.fetchall():
-            cursor.execute('CREATE LANGUAGE plpgsql')
-        installed_triggers = self.installed_triggers()
-        if len(installed_triggers) > 0:
-            installed_triggers = zip(*installed_triggers)[0]  # get just the names
-        for name, trigger in self.triggers.items():
-            if name in installed_triggers:
-                continue
-            sql, args = trigger.sql()
-            cursor.execute(sql, args)
-            yield trigger
-
-    def install(self):
-        try:
-            with transaction.atomic():
-                ret = list(self.install_atomic())
-        except AttributeError:
-            ret = list(self.install_atomic())
-            transaction.commit_unless_managed(using=self.using)
-        return ret

--- a/denorm/db/sqlite3/triggers.py
+++ b/denorm/db/sqlite3/triggers.py
@@ -146,7 +146,8 @@ class TriggerSet(base.TriggerSet):
     def install_atomic(self):
         cursor = self.cursor()
         installed_triggers = self.installed_triggers()
-        installed_triggers = zip(*installed_triggers)[0]  # get just the names
+        if len(installed_triggers) > 0:
+            installed_triggers = zip(*installed_triggers)[0]  # get just the names
         for name, trigger in self.triggers.items():
             if name in installed_triggers:
                 continue

--- a/denorm/db/sqlite3/triggers.py
+++ b/denorm/db/sqlite3/triggers.py
@@ -112,54 +112,7 @@ class TriggerSet(base.TriggerSet):
         cursor.execute("SELECT name, tbl_name FROM sqlite_master WHERE type = 'trigger' AND name LIKE 'denorm_%%';")
         return cursor.fetchall()
 
-    def drop_atomic(self):
+    def drop_trigger(self, trigger_name, table_name):
         qn = self.connection.ops.quote_name
         cursor = self.cursor()
-        for trigger_name, table_name in self.installed_triggers():
-            cursor.execute("DROP TRIGGER %s;" % (qn(trigger_name),))
-
-    def drop(self):
-        try:
-            with transaction.atomic():
-                self.drop_atomic()
-        except AttributeError:
-            self.drop_atomic()
-            transaction.commit_unless_managed(using=self.using)
-
-    def drop_unneeded_atomic(self):
-        qn = self.connection.ops.quote_name
-        cursor = self.cursor()
-        needed_triggers = self.triggers.keys()
-        for trigger_name, table_name in self.installed_triggers():
-            if trigger_name in needed_triggers:
-                continue
-            cursor.execute('DROP TRIGGER %s;' % (qn(trigger_name),))
-
-    def drop_unneeded(self):
-        try:
-            with transaction.atomic():
-                self.drop_unneeded_atomic()
-        except AttributeError:
-            self.drop_unneeded_atomic()
-            transaction.commit_unless_managed(using=self.using)
-
-    def install_atomic(self):
-        cursor = self.cursor()
-        installed_triggers = self.installed_triggers()
-        if len(installed_triggers) > 0:
-            installed_triggers = zip(*installed_triggers)[0]  # get just the names
-        for name, trigger in self.triggers.items():
-            if name in installed_triggers:
-                continue
-            sql, args = trigger.sql()
-            cursor.execute(sql, args)
-            yield trigger
-
-    def install(self):
-        try:
-            with transaction.atomic():
-                ret = list(self.install_atomic())
-        except AttributeError:
-            ret = list(self.install_atomic())
-            transaction.commit_unless_managed(using=self.using)
-        return ret
+        cursor.execute("DROP TRIGGER %s;" % (qn(trigger_name),))

--- a/denorm/denorms.py
+++ b/denorm/denorms.py
@@ -610,6 +610,11 @@ def build_triggerset(using=None):
 
 
 def smart_db_refresh(using=None):
+    """
+    Drops any triggers that are no longer needed and
+    Installs any triggers that are newly needed and
+    Dirties all effected objects
+    """
     from .models import DirtyInstance
     from .db import triggers
     alldenorms = get_alldenorms()

--- a/denorm/denorms.py
+++ b/denorm/denorms.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import abc
+from collections import defaultdict
 
 from django.contrib import contenttypes
 from django.db import connections, connection
@@ -544,12 +545,21 @@ class CountDenorm(AggregateDenorm):
         return self.get_decrement_value(using)
 
 
+def dirty_entire_model(model):
+    from .models import DirtyInstance
+    content_type = contenttypes.models.ContentType.objects.get_for_model(model)
+    for instance in model.objects.all():
+        DirtyInstance.objects.create(
+            content_type=content_type,
+            object_id=instance.pk,
+        )
+
+
 def rebuildall(verbose=False, model_name=None, field_name=None):
     """
     Updates all models containing denormalized fields.
     Used by the 'denormalize' management command.
     """
-    from .models import DirtyInstance
     alldenorms = get_alldenorms()
     models = {}
     for denorm in alldenorms:
@@ -571,12 +581,7 @@ def rebuildall(verbose=False, model_name=None, field_name=None):
                 print(msg)
                 i += 1
         # create DirtyInstance for all objects, so the rebuild is done during flush
-        content_type = contenttypes.models.ContentType.objects.get_for_model(model)
-        for instance in model.objects.all():
-                DirtyInstance.objects.create(
-                    content_type=content_type,
-                    object_id=instance.pk,
-                )
+        dirty_entire_model(model)
     flush(verbose)
 
 
@@ -602,6 +607,29 @@ def build_triggerset(using=None):
     for denorm in alldenorms:
         triggerset.append(denorm.get_triggers(using=using))
     return triggerset
+
+
+def smart_db_refresh(using=None):
+    from .models import DirtyInstance
+    from .db import triggers
+    alldenorms = get_alldenorms()
+    trigger_to_models_map = defaultdict(set)
+    triggerset = triggers.TriggerSet(using=using)
+    for denorm in alldenorms:
+        triggers = denorm.get_triggers(using=using)
+        triggerset.append(triggers)
+        for trigger in triggers:
+            trigger_to_models_map[trigger.name()].add(denorm.model)
+    triggerset.drop_unneeded()
+    added_triggers = triggerset.install()
+    models_to_dirty = set()
+    for trigger in added_triggers:
+        for model in trigger_to_models_map[trigger.name()]:
+            models_to_dirty.add(model)
+    for model in models_to_dirty:
+        print 'Added triggers for and recomputing %s' % model
+        dirty_entire_model(model)
+    flush(verbose=True)
 
 
 def flush(verbose=False):

--- a/denorm/management/commands/denorm_migrate.py
+++ b/denorm/management/commands/denorm_migrate.py
@@ -1,0 +1,13 @@
+from django.core.management.base import BaseCommand
+from denorm import denorms
+
+
+class Command(BaseCommand):
+    help = """Migrate: to run on every release
+        Calculates the difference between triggers in the db
+        and triggers needed by the current version of your code
+        and applies the set of changes needed and recomputes appropriately
+    """
+
+    def handle(self, **kwargs):
+        denorms.smart_db_refresh()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Django==1.5
+Django==1.7.1
 coverage
 psycopg2

--- a/test_denorm_project/test_app/migrations/0004_auto_20160218_1249.py
+++ b/test_denorm_project/test_app/migrations/0004_auto_20160218_1249.py
@@ -8,7 +8,7 @@ import denorm.fields
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('test_app', '0002_auto_20151014_1049'),
+        ('test_app', '0003_auto_20160119_0522'),
     ]
 
     operations = [

--- a/test_denorm_project/test_app/migrations/0005_auto_20160428_1816.py
+++ b/test_denorm_project/test_app/migrations/0005_auto_20160428_1816.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('test_app', '0004_auto_20160218_1249'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='forum',
+            name='authors',
+            field=models.ManyToManyField(to='test_app.Member', editable=False, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/test_denorm_project/test_app/tests.py
+++ b/test_denorm_project/test_app/tests.py
@@ -701,14 +701,6 @@ class CommandsTestCase(TransactionTestCase):
 
         call_command('denorm_daemon', run_once=True, foreground=True)
 
-    if Decimal('.'.join([str(i) for i in django.VERSION[:2]])) >= Decimal('1.7'):
-        def test_makemigrations(self):
-            " Test makemigrations command."
-
-            args = []
-            opts = {}
-            call_command('makemigrations', *args, **opts)
-
 
 class UpdateTriggersOnModelChangesTestCase(TransactionTestCase):
     def setUp(self):

--- a/test_denorm_project/test_app/tests.py
+++ b/test_denorm_project/test_app/tests.py
@@ -708,3 +708,12 @@ class CommandsTestCase(TransactionTestCase):
             args = []
             opts = {}
             call_command('makemigrations', *args, **opts)
+
+
+class UpdateTriggersOnModelChangesTestCase(TransactionTestCase):
+    def setUp(self):
+        call_command('migrate', 'test_app', '0001_initial')
+
+    def test_denorm_migrate(self):
+        call_command('migrate', 'test_app')
+        call_command('denorm_migrate')


### PR DESCRIPTION
For denorm to be useful to us we would have to have an efficient and convenient way to add and remove denorm fields in our app.  This new command accomplishes that by comparing installed triggers to the current set of triggers needed, and only performing the drops / installs needed to make up the difference.

The intension is that this command can be used as a general purpose post-deploy step for an application.

Tested end to end against our own models.  

Todo:
- [x] Dry up some of the triggerset code
- [x] Unit test
